### PR TITLE
Upgrade spekframework2 from 2.0.14 to 2.0.15

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,4 +19,4 @@ version.org.awaitility..awaitility-kotlin=4.0.3
 
 version.org.json..json=20201115
 
-version.spekframework2=2.0.14
+version.spekframework2=2.0.15


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.