### PR TITLE
Upgrade spekframework2 from 2.0.15 to 2.0.17

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -27,4 +27,4 @@ version.org.awaitility..awaitility-kotlin=4.1.0
 
 version.org.json..json=20210307
 
-version.spekframework2=2.0.15
+version.spekframework2=2.0.17


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.