### PR TITLE
Fix #88 illegal access - "module java.base does not "opens java.net" …

### DIFF
--- a/src/main/kotlin/khttp/requests/GenericRequest.kt
+++ b/src/main/kotlin/khttp/requests/GenericRequest.kt
@@ -200,16 +200,9 @@ class GenericRequest internal constructor(
 
     private fun URL.toIDN(): URL {
         val newHost = IDN.toASCII(this.host)
-        this.javaClass.getDeclaredField("host").apply { this.isAccessible = true }.set(this, newHost)
-        this.javaClass.getDeclaredField("authority").apply { this.isAccessible = true }.set(this, if (this.port == -1) this.host else "${this.host}:${this.port}")
-        val query = if (this.query == null) {
-            null
-        } else {
-            URLDecoder.decode(this.query, "UTF-8")
-        }
-        return URL(URI(this.protocol, this.userInfo, this.host, this.port, this.path, query, this.ref).toASCIIString())
+        val query = this.query ?. let { URLDecoder.decode(it, "UTF-8") }
+        return URL(URI(this.protocol, this.userInfo, newHost, this.port, this.path, query, this.ref).toASCIIString())
     }
-
     private fun makeRoute(route: String) = URL(route + if (this.params.isNotEmpty()) "?${Parameters(this.params)}" else "").toIDN().toString()
 
 }


### PR DESCRIPTION
…to unnamed"

Fix  'Unable to make field private java.lang.String java.net.URL.host accessible: module java.base does not "opens java.net" to unnamed'